### PR TITLE
add repository to dist metadata

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,6 +31,16 @@ WriteMakefile(
         "Time::HiRes"      => 0,    # Usually core now
         "fields"           => 0,
     },
+    META_MERGE => {
+        'meta-spec' => { version => 2 },
+        resources => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/p-alik/perl-Gearman.git',
+                web  => 'https://github.com/p-alik/perl-Gearman',
+            },
+        },
+    },
 );
 
 1;


### PR DESCRIPTION
Adding the github repository to the dist metadata will make metacpan link directly to the github repository and make it easier for developers to find the repository and make PRs directly to it.
