### PR TITLE
switch to blocking to continue fetching partial read

### DIFF
--- a/lib/Gearman/Util.pm
+++ b/lib/Gearman/Util.pm
@@ -215,7 +215,10 @@ sub _read_sock {
         $$offset_ref += $rv;
         $$readlen_ref -= $rv;
 
-        return _read_sock($sock, $buf_ref, $readlen_ref, $offset_ref);
+        $sock->blocking(1);
+        my $ret = _read_sock($sock, $buf_ref, $readlen_ref, $offset_ref);
+        $sock->blocking(0);
+        return $ret;
     } ## end unless ($rv >= $$readlen_ref)
 
     warn "   Finished reading\n" if DEBUG;


### PR DESCRIPTION
Hello,

this patch is an improvement (code works also without) to temporary turn on blocking for sysread() call when the next packet to arrive must the rest of fragmented data. Under heavy load circumstances, when the next fragment is not yet there, will save some EAGAIN and some loop cycles.

Best regards
Jozef