### PR TITLE
sysread() only as much data from the stream as needed

### DIFF
--- a/lib/Gearman/ResponseParser.pm
+++ b/lib/Gearman/ResponseParser.pm
@@ -171,7 +171,8 @@ C<$sock> is readable, we should sysread it and feed it to L<parse_data($data)>
 sub parse_sock {
     my ($self, $sock) = @_;
     my $data;
-    my $rv = sysread($sock, $data, 128 * 1024);
+    my $need = (length($self->{header}) ? ($self->{pkt}{len} - length(${ $self->{pkt}{blobref} })) : 12);
+    my $rv = sysread($sock, $data, $need);
 
     if (!defined $rv) {
         $self->on_error("read_error: $!");

--- a/t/19-add_task-in-cb.t
+++ b/t/19-add_task-in-cb.t
@@ -1,0 +1,79 @@
+use strict;
+use warnings;
+
+# OK gearmand v1.0.6
+
+use List::Util qw/ sum /;
+use Storable qw/
+    freeze
+    thaw
+    /;
+use Test::Exception;
+use Test::More;
+
+use lib '.';
+use t::Server ();
+use t::Worker qw/ new_worker /;
+
+my $gts         = t::Server->new();
+my @job_servers = $gts->job_servers(int(rand(1) + 1));
+@job_servers || plan skip_all => $t::Server::ERROR;
+plan tests => 3;
+
+use_ok("Gearman::Client");
+
+my $client = new_ok("Gearman::Client",
+    [exceptions => 1, job_servers => [@job_servers]]);
+
+my $data_size = 200_000;
+my $func = "bigdata";
+my $cb   = sub {
+    return '~' x $data_size;
+};
+
+my @workers
+    = map(new_worker(job_servers => [@job_servers], func => { $func, $cb }),
+    (0 .. 1));
+
+subtest "add_task() call-back adding more tasks via add_task()", sub {
+    plan tests => 4;
+
+    my $loops = 10;
+    my $re_add_every = 3;
+
+    isa_ok my $ts = $client->new_task_set, "Gearman::Taskset";
+
+    my $failed = 0;
+    my $incorrect = 0;
+    my $passed = 0;
+    my $on_complete_cb = sub { length( ${ $_[0] } ) == $data_size ? $passed++ : $incorrect++; };
+    my $on_fail_cb = sub { $failed++ };
+    foreach my $i (1..$loops) {
+        $ts->add_task(
+            bigdata => freeze( [] ), {
+               on_complete => sub {
+                   $on_complete_cb->(@_);
+                   if ($i % $re_add_every == 0) {
+                       $ts->add_task(
+                                      bigdata => freeze( [] ), {
+                                        on_complete => $on_complete_cb,
+                                        on_fail     => $on_fail_cb,
+                                      }
+                       );
+                    }
+               },
+               on_fail => $on_fail_cb,
+            }
+            ) || $failed++;
+    }
+
+    note "wait";
+    $ts->wait;
+
+    is($passed, ($loops + int($loops / $re_add_every)), "all tasks passed");
+    is($incorrect, 0, "all correct");
+    is($failed, 0, "no fails");
+};
+
+
+done_testing();


### PR DESCRIPTION
Hello,

this patch fixes race-condition in case add_task() call-back is adding more tasks during wait().

There are two places where sysread() is used in Gearman::Client, once when adding task, there only the minimum requested bytes are read using sysread(). The second place is in taskset->wait()  loop where there was fixed size limit of 128 * 1024 set. Under heavy loads with responses of multiple kilobytes of data it is possible that gearman sends last fragment of data and next command in one packet. This will be read out. The last fragment part will trigger call-back and when in this call-back add_task() is executed, it will write and read some out of sync chunk of data, because the first part of data was already read for wait() loop.

This fix is that only the amount of data needed for a header and response will be fetched via sysread().

Without the patch `t/19-add_task-in-cb.t` was failing with:

> t/19-add_task-in-cb.t .. 
> 1..3
> ok 1 - use Gearman::Client;
> ok 2 - An object of class 'Gearman::Client' isa 'Gearman::Client'
>     # Subtest: add_task() call-back adding more tasks via add_task()
>     1..4
>     ok 1 - An object of class 'Gearman::Taskset' isa 'Gearman::Taskset'
>     # wait
> Job server failure: reading response packet failed: malformed_magic: '~~~~' at t/19-add_task-in-cb.t line 56.
>  at t/19-add_task-in-cb.t line 71.

Best regards
Jozef