### PR TITLE
fix funcname regexp. it may include a prefix_separator tab.

### DIFF
--- a/lib/Gearman/Client.pm
+++ b/lib/Gearman/Client.pm
@@ -245,7 +245,7 @@ sub get_job_server_status {
         "status\n",
         sub {
             my ($js, $line) = @_;
-            unless ($line =~ /^(\S+)\s+(\d+)\s+(\d+)\s+(\d+)$/) {
+            unless ($line =~ /^(.+)\s(\d+)\s+(\d+)\s+(\d+)$/) {
                 return;
             }
 


### PR DESCRIPTION
Hello,

If prefix is used as follows, get_job_server_status cannot get information.
```
my $client = Gearman::Client->new( job_servers => ['127.0.0.1:4730'], prefix => 'myapp' ) 
$client->get_job_server_status;
```

The function name can contain anything. For example 
```
gearman -w -f "prefix1| \t\n^Mfunc1日本語UTF-8"
```

First of all, I hope that it will work even if the default value tab of prefix_separator is included.

Thanks,