### PR TITLE
Minor correction to error reporting in Gearman::ResponseParse::parse_sock()

### DIFF
--- a/lib/Gearman/ResponseParser.pm
+++ b/lib/Gearman/ResponseParser.pm
@@ -172,7 +172,7 @@ sub parse_sock {
     my ($self, $sock) = @_;
     my $res = Gearman::Util::read_res_packet($sock, \my $err);
     if ($err) {
-        $self->on_error("read_error: ${$err}");
+        $self->on_error("read_error: $err");
         return;
     }
 


### PR DESCRIPTION
As discussed in issue #50, this trivial PR makes a minor correction to the error reporting in `Gearman::ResponseParse::parse_sock()`.